### PR TITLE
[SE-385] Give state a unique name that isn't used by other appd formula

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -74,8 +74,9 @@ create-appdynamics-dbagent-service-symlink:
     - watch:
       - file: appdynamics-dbagent-init-script
 
-{{ appd.user }}:
+ensure-user-present:
   user.present
+    - name: {{ appd.user }}
 
 ### FILES ###
 {{ appd.prefix }}/appdynamics-dbagent/conf/controller-info.xml:


### PR DESCRIPTION
The `appdynamics-formula` repo already has a state called `appdynamics`.
Rename this one, and explicitly set the `name` parameter for the
`user.present` function rather than relying on the state ID to be used as the
implicit name.